### PR TITLE
fixes typo for non-plural reaction count

### DIFF
--- a/src/emojissue.js
+++ b/src/emojissue.js
@@ -18,10 +18,14 @@
   const positiveEmojis = ['heart', '+1', 'tada'];
 
   // Generate content
-  const generateHTML = args => `
-    <span class="emoji">🤘</span> See #${args.currentIndex + 1}
-    <span class="reacts">+${args.topFive[args.currentIndex].score} Reacts</span>
-  `;
+  const generateHTML = args => {
+    const reactionPlaceholder =
+      args.topFive[args.currentIndex].score > 1 ? 'reactions' : 'reaction';
+    return `
+      <span class="emoji">🤘</span> See #${args.currentIndex + 1}
+      <span class="reacts">+${args.topFive[args.currentIndex].score} ${reactionPlaceholder}</span>
+    `;
+  };
 
   // Collect top five reacted comments
   const collectMostReactedComments = allComments => {


### PR DESCRIPTION
Hi @alpcanaydin,
I prepared a fix for displaying "reaction" instead of "reactions" when the reaction count is not plural. Also, I've changed "Reacts" as "reactions" to make it more understandable. If that is not suitable for you we can go back to previous version of this placeholder.